### PR TITLE
Add handling for sensor range exceeding 12.0

### DIFF
--- a/tfmini_ros/src/TFmini_ros_node.cpp
+++ b/tfmini_ros/src/TFmini_ros_node.cpp
@@ -42,6 +42,12 @@ int main(int argc, char **argv)
     {
       ROS_ERROR_STREAM("Data validation error!");
     }
+    else
+		{
+			// When the real range exceeds 12.0, but there is an object further, in some cases the sensor returns value > 12.0.
+      // Set the range to max if that happens.
+			TFmini_range_.range = 12.0;
+		}
   }
 
   tfmini_obj->closePort();


### PR DESCRIPTION
In some cases, when the object is further than the max range, the sensor returns 13.0 as a value. The case was not handled in the driver, causing old values to persist and keep being published. In some scenarios, it was causing values lower than the last correct one to keep being published over and over, causing issues.